### PR TITLE
fix(dynamic): 修复批量操作可能为空导致的空指针异常- 在 doBatchActionWithResults 方法中增加了对 …

### DIFF
--- a/src/main/java/com/github/wz2cool/dynamic/mybatis/mapper/batch/MapperBatchAction.java
+++ b/src/main/java/com/github/wz2cool/dynamic/mybatis/mapper/batch/MapperBatchAction.java
@@ -1,15 +1,16 @@
 package com.github.wz2cool.dynamic.mybatis.mapper.batch;
 
 import com.github.wz2cool.dynamic.mybatis.mapper.DynamicQueryMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 import org.apache.ibatis.executor.BatchResult;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * @author Frank
@@ -54,6 +55,9 @@ public class MapperBatchAction<M extends DynamicQueryMapper<?>> {
      * @return batch result.
      */
     public List<BatchResult> doBatchActionWithResults() {
+        if (Objects.isNull(this.actions) || this.actions.isEmpty()) {
+            return Collections.emptyList();
+        }
         List<BatchResult> result = new ArrayList<>();
         try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH, false)) {
             final M mapper = sqlSession.getMapper(mapperClass);


### PR DESCRIPTION
…actions 的空值和空集合检查

- 如果 actions为空，直接返回空集合，避免执行空批量操作
- 优化了代码结构，提高了代码的健壮性和可读性